### PR TITLE
Remove references to nose and use unittest plainly instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.5"
   - "3.6"
 script:
-  - python manage.py test --noinput
+  - coverage run --source='.' manage.py test --noinput && coverage report
 install:
   - pip install -r dev-requirements.txt
 before_install:

--- a/configuration/settings.py
+++ b/configuration/settings.py
@@ -10,6 +10,7 @@ PROJECT_VARIABLE_PATTERN = '_'.join((PROJECT_NAME, '{}'))
 def get_env_var(var_name, default=None):
     return os.getenv(PROJECT_VARIABLE_PATTERN.format(var_name), default)
 
+
 SITE_NAME = 'Dane Hillard Photography'
 
 SECRET_KEY = get_env_var('SECRET_KEY')

--- a/configuration/settings.py
+++ b/configuration/settings.py
@@ -143,7 +143,6 @@ THIRD_PARTY_APPS = [
 
 if DEBUG:
     THIRD_PARTY_APPS += [
-        'django_nose',
         'debug_toolbar',
     ]
 
@@ -219,17 +218,6 @@ LOGGING = {
         } for app in MY_APPS
     },
 }
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '-d',
-    '--quiet',
-    '--with-fixture-bundling',
-    '--with-coverage',
-    '--cover-package=.',
-    '--cover-erase',
-]
 
 WHITELISTED_CRAWLERS = {
     'facebook': [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 
 django-debug-toolbar==1.5
-django-nose==1.4.4


### PR DESCRIPTION
After learning that `nose` is no longer maintained, switching to the default `unittest` runner and running `coverage` explicitly during builds.