### PR TITLE
Fix broken collapsed navigation for mobile screens

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,2 +1,4 @@
+import 'jquery';
+import 'bootstrap-sass/assets/javascripts/bootstrap';
 import '../../node_modules/lightbox2/src/css/lightbox.css';
 import '../css/site.scss';

--- a/package-lock.json
+++ b/package-lock.json
@@ -4384,9 +4384,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
-      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
     "js-base64": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.11",
     "imagesloaded": "^4.1.4",
-    "jquery": "^3.4.0",
+    "jquery": "^3.4.1",
     "lightbox2": "^2.11.0",
     "masonry-layout": "^4.2.2",
     "node-sass": "^4.12.0",

--- a/templates/__base.html
+++ b/templates/__base.html
@@ -90,6 +90,7 @@
         </div>
 
         {% block js %}
+            {% render_bundle 'main' 'js' %}
             {% block disqus_js %}
             <script type="text/javascript">
                 {% include 'disqus.js' %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const BundleTracker = require('webpack-bundle-tracker');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = {
     context: __dirname,
@@ -48,6 +49,12 @@ module.exports = {
             uglifyOptions: {
                 warnings: false
             }
+        }),
+        new webpack.ProvidePlugin({
+            $: "jquery",
+            jquery: "jquery",
+            "window.jQuery": "jquery",
+            jQuery:"jquery"
         }),
         new ExtractTextPlugin('[name]-[hash:6].css'),
         new BundleTracker({filename: './webpack-stats.json'})


### PR DESCRIPTION
Somehow this slipped past me; Bootstrap's JavaScript was not being
loaded, so the collapsible navigation on mobile was broken. Added
Bootstrap (and jQuery) back into the mix.